### PR TITLE
fix: web font Pretendard 미적용 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
 				"hls.js": "^1.6.5",
 				"mixpanel-browser": "^2.67.0",
 				"next": "15.3.2",
-				"pretendard": "^1.3.9",
 				"radix-ui": "^1.4.2",
 				"react": "^18.2.0",
 				"react-chat-elements": "^12.0.18",
@@ -11480,12 +11479,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/pretendard": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
-			"integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
-			"license": "OFL-1.1"
 		},
 		"node_modules/prettier": {
 			"version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"hls.js": "^1.6.5",
 		"mixpanel-browser": "^2.67.0",
 		"next": "15.3.2",
-		"pretendard": "^1.3.9",
 		"radix-ui": "^1.4.2",
 		"react": "^18.2.0",
 		"react-chat-elements": "^12.0.18",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
 @import "tailwindcss";
 
 @theme {
@@ -60,7 +62,7 @@
 :root {
 	--background: #ffffff;
 	--foreground: #171717;
-	--font-family: "Pretendard", sans-serif;
+	--font-family: "Pretendard Variable", sans-serif;
 	--font-feature-settings: "ss05";
 	font-feature-settings: "ss05";
 }
@@ -68,8 +70,8 @@
 @theme inline {
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
-	--font-sans: "Pretendard", sans-serif;
-	--font-mono: "Pretendard", sans-serif;
+	--font-sans: "Pretendard Variable", sans-serif;
+	--font-mono: "Pretendard Variable", sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -82,7 +84,7 @@
 body {
 	background: var(--background);
 	color: var(--foreground);
-	font-family: "Pretendard", sans-serif;
+	font-family: "Pretendard Variable", sans-serif;
 }
 
 .codeblock-group {

--- a/src/app/resetTheme.ts
+++ b/src/app/resetTheme.ts
@@ -2,8 +2,8 @@ import { extendTheme } from "@chakra-ui/react";
 
 const resetTheme = extendTheme({
 	fonts: {
-		heading: `'Pretendard', sans-serif`,
-		body: `'Pretendard', sans-serif`,
+		heading: `'Pretendard Variable', sans-serif`,
+		body: `'Pretendard Variable', sans-serif`,
 	},
 });
 


### PR DESCRIPTION
## 🪐 작업 내용

@KBG1 범규님이 일러주신 웹 폰트 최적화 관련해서 수정했습니다.


## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [ x] merge할 브랜치의 위치를 확인했나요?

## Screen Shot(optional)

<!-- 화면 개발 스크린 샷 -->

## 💬 review require(optional)

"ㅎ" 보시면 Pretendard 적용 전은 "으" 모양, 적용 후는 "오" 모양입니다.  참고하시면 되겠습니다~!